### PR TITLE
Fix a bad copy paste

### DIFF
--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -152,10 +152,8 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 
 ### Example Response
 
-```json:title=/bots/9876/check?userId%3D1234
-{
-  "voted": 1
-}
+```json:title=/bots/1234/stats
+{}
 ```
 
 ## Bot Structure


### PR DESCRIPTION
The previous documentation was wrong there.

My test case : 
```shell
❯ curl -X POST 'https://top.gg/api/bots/187636089073172481/stats' -H "Content-Type: application/json" -d '{"server_count":14122,"shards":[],"shard_count":14}' -H "Authorization: TOKEN"
{}
```