### PR TITLE
Fixed a typo on the "Users" page

### DIFF
--- a/content/api/user.mdx
+++ b/content/api/user.mdx
@@ -9,7 +9,7 @@ A user represents a User account in top.gg. It is not associated with any other 
 
 ## Find One User
 
-<HTTPHeader type="GET" path="/user/:user_id" />
+<HTTPHeader type="GET" path="/users/:user_id" />
 
 Retrieves information about a particular user by their Discord user id.
 


### PR DESCRIPTION
I just changed "GET /user/:user_id" to "GET /users/:user_id"