### PR TITLE
Introduce TopPHP API wrapper.

### DIFF
--- a/content/libraries/php.mdx
+++ b/content/libraries/php.mdx
@@ -5,11 +5,15 @@ description: Official Top.gg PHP library
 
 # PHP Library
 
-This is our official PHP Library for top.gg, if you have any issues/bugs please submit an issue on our github.
+This is our official PHP Library for top.gg, if you have any issues/bugs please submit an issue on the repository.
 
-- [GitHub Link](https://github.com/vapourlabs/TopPHP)
+- [GitHub Link](https://github.com/top-gg/php-sdk)
 
-(I cannot make a repo for the actual /top-gg/php-sdk version, so a clone will be req.)
+## Installation
+
+Please run the following line in Composer in order to access the library:
+
+```composer require top-gg/php-sdk```
 
 ## Usage
 

--- a/content/libraries/php.mdx
+++ b/content/libraries/php.mdx
@@ -1,0 +1,27 @@
+---
+title: PHP
+description: Official Top.gg PHP library
+---
+
+# PHP Library
+
+This is our official PHP Library for top.gg, if you have any issues/bugs please submit an issue on our github.
+
+- [GitHub Link](https://github.com/top-gg/php-sdk)
+
+## Usage
+
+For our full/comprehensive list of usage, please refer to the github docs.
+
+### Posting bot stats
+
+Posting your bot's statistics is very simple and easily able to be done through the code shown here.
+
+```php
+$bot = new Discord(["token" => "YOUR_BOT_TOKEN"]); # DiscordPHP/Restcord Client
+$DBL = new TopGG("YOUR_API_TOKEN");
+
+// You could also pass a check with $DBL->POST->stats(...)->RESP instead.
+$DBL->POST->stats($bot->id, count($bot->guilds));
+if($DBL->RESP == 200) echo "Stats were successfully updated.";
+```

--- a/content/libraries/php.mdx
+++ b/content/libraries/php.mdx
@@ -7,7 +7,9 @@ description: Official Top.gg PHP library
 
 This is our official PHP Library for top.gg, if you have any issues/bugs please submit an issue on our github.
 
-- [GitHub Link](https://github.com/top-gg/php-sdk)
+- [GitHub Link](https://github.com/vapourlabs/TopPHP)
+
+(I cannot make a repo for the actual /top-gg/php-sdk version, so a clone will be req.)
 
 ## Usage
 


### PR DESCRIPTION
This would introduce the TopPHP API wrapper library officially to the Top.GG docs page and give an example, as well as calling the new source as "php-sdk." I, unfortunately, have no ability to create the directory myself but approve of whatever motion that carries with it being added in.