### PR TITLE
[bots] Discriminators are no-longer returned on /votes

### DIFF
--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -96,7 +96,6 @@ This example uses Luca but users are restricted to only receiving their own bots
 [
   {
     "username": "Xetera",
-    "discriminator": "0001",
     "id": "140862798832861184",
     "avatar": "a_1241439d430def25c100dd28add2d42f"
   }


### PR DESCRIPTION
I recently discovered that top.gg no-longer returns discriminators for `/bots/:id/votes`. For example:

```json
[
    {
        "username": "Plague Doctor",
        "id": "...",
        "avatar": "https://cdn.discordapp.com/avatars/401797901673824256/8e9cef809b76417fafda20843b012280.webp?size=256"
    },
    {
        "username": "TurtleMan",
        "id": "...",
        "avatar": "https://cdn.discordapp.com/avatars/123868938646978564/a_362438f5000f5301f0957bb5c244503e.webp?size=256"
    },
    {
        "username": "eek",
        "id": "421698654189912064",
        "avatar": "https://cdn.discordapp.com/avatars/421698654189912064/aa494f50d7fca1fa81f4fd1d8aaa2cb1.webp?size=256"
    },
]
```
If this is not a purposeful change, please let me know. Otherwise, I've updated the docs to reflect this change.

## TL;DR
API no-longer returns discriminators for /bots/:id/votes, reflected in docs.