### PR TITLE
Change discord.gg/dbl to the actual invite code

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -11,6 +11,6 @@ If you're looking for API usage, check out the `API` section on the sidebar.
 
 ## Getting Help
 
-If you need some help or think you have spotted a problem with our API you can talk to us in our [`#api`](https://discord.com/channels/264445053596991498/412006692125933568) channel in our [discord server](https://discord.gg/dbl).
+If you need some help or think you have spotted a problem with our API you can talk to us in our [`#api`](https://discord.com/channels/264445053596991498/412006692125933568) channel in our [discord server](https://discord.gg/EYHTgJX).
 
 In the server you can ask questions about our official API Libraries or general queries about the API.


### PR DESCRIPTION
Because the server doesn't have actual partner/verification, I believe the vanity URL is unreliable and shouldn't be used.