### PR TITLE
Add server count to bot structure

### DIFF
--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -178,8 +178,8 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 | guilds           | `snowflake[]` | of Snowflakes The guilds featured on the bot page                             |
 | invite?          | `string`      | The custom bot invite url of the bot                                          |
 | date             | `datestring`  | The date when the bot was approved                                            |
-| server_count     | `number`      | The amount of servers the bot has according to posted stats.                  |
-| shard_count      | `number`      | The amount of shards the bot has according to posted stats.                   |
+| server_count?    | `number`      | The amount of servers the bot has according to posted stats.                  |
+| shard_count?     | `number`      | The amount of shards the bot has according to posted stats.                   |
 | certifiedBot     | `boolean`     | The certified status of the bot                                               |
 | vanity?          | `string`      | The vanity url of the bot                                                     |
 | points           | `number`      | The amount of upvotes the bot has                                             |

--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -179,6 +179,7 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 | invite?          | `string`      | The custom bot invite url of the bot                                          |
 | date             | `datestring`  | The date when the bot was approved                                            |
 | server_count     | `number`      | The amount of servers the bot has according to posted stats.                  |
+| shard_count      | `number`      | The amount of shards the bot has according to posted stats.                   |
 | certifiedBot     | `boolean`     | The certified status of the bot                                               |
 | vanity?          | `string`      | The vanity url of the bot                                                     |
 | points           | `number`      | The amount of upvotes the bot has                                             |
@@ -205,6 +206,7 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
   "username": "Luca",
   "date": "2017-04-26T18:08:17.125Z",
   "server_count": 2,
+  "shard_count": 1,
   "guilds": ["417723229721853963", "264445053596991498"],
   "shards": [],
   "monthlyPoints": 19,

--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -178,6 +178,7 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 | guilds           | `snowflake[]` | of Snowflakes The guilds featured on the bot page                             |
 | invite?          | `string`      | The custom bot invite url of the bot                                          |
 | date             | `datestring`  | The date when the bot was approved                                            |
+| server_count     | `number`      | The amount of servers the bot has according to posted stats.                  |
 | certifiedBot     | `boolean`     | The certified status of the bot                                               |
 | vanity?          | `string`      | The vanity url of the bot                                                     |
 | points           | `number`      | The amount of upvotes the bot has                                             |


### PR DESCRIPTION
Currently, `server_count` is not documented under the Bot Structure API response when it is cited in the example response below it.