### PR TITLE
Update HTTPHeader to fix double slash

### DIFF
--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -9,7 +9,7 @@ import HTTPHeader from "@components/HTTPHeader";
 
 ## Search Bots
 
-<HTTPHeader type="GET" path="/bots" />
+<HTTPHeader type="GET" path="bots" />
 
 Gets a list of bots that match a specific query.
 
@@ -72,7 +72,7 @@ Gets a list of bots that match a specific query.
 
 ## Find One Bot
 
-<HTTPHeader type="GET" path="/bots/:bot_id" />
+<HTTPHeader type="GET" path="bots/:bot_id" />
 
 Finds a single bot
 
@@ -82,7 +82,7 @@ Finds a single bot
 
 ## Last 1000 Votes
 
-<HTTPHeader type="GET" path="/bots/:bot_id/votes" />
+<HTTPHeader type="GET" path="bots/:bot_id/votes" />
 
 Gets the last 1000 voters for your bot.
 
@@ -104,7 +104,7 @@ This example uses Luca but users are restricted to only receiving their own bots
 
 ## Bot stats
 
-<HTTPHeader type="GET" path="/bots/:bot_id/stats" />
+<HTTPHeader type="GET" path="bots/:bot_id/stats" />
 
 Specific stats about a bot.
 
@@ -118,7 +118,7 @@ Specific stats about a bot.
 
 ## Individual User Vote
 
-<HTTPHeader type="GET" path="/bots/:bot_id/check" />
+<HTTPHeader type="GET" path="bots/:bot_id/check" />
 
 Checking whether or not a user has voted for your bot. Safe to use even if you have over 1k monthly votes.
 
@@ -138,7 +138,7 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 
 ## Post Stats
 
-<HTTPHeader type="POST" path="/bots/:bot_id/stats" />
+<HTTPHeader type="POST" path="bots/:bot_id/stats" />
 
 ### Post Body
 

--- a/content/api/user.mdx
+++ b/content/api/user.mdx
@@ -9,7 +9,7 @@ A user represents a User account in top.gg. It is not associated with any other 
 
 ## Find One User
 
-<HTTPHeader type="GET" path="/users/:user_id" />
+<HTTPHeader type="GET" path="users/:user_id" />
 
 Retrieves information about a particular user by their Discord user id.
 

--- a/src/components/HTTPHeader.jsx
+++ b/src/components/HTTPHeader.jsx
@@ -64,7 +64,8 @@ export default function HTTPHeader({ type, path }) {
       setTimeout(() => setCopy(false), 3000);
     }
   }, [copied]);
-  const fullUrl = `https://top.gg/api${path}`;
+  const BASE_URL = "https://top.gg/api/";
+  const fullUrl = new URL(path, BASE_URL).href;
   const url = path;
   return (
     <HeaderWrapper method={type}>

--- a/src/components/HTTPHeader.jsx
+++ b/src/components/HTTPHeader.jsx
@@ -64,7 +64,7 @@ export default function HTTPHeader({ type, path }) {
       setTimeout(() => setCopy(false), 3000);
     }
   }, [copied]);
-  const fullUrl = `https://top.gg/api/${path}`;
+  const fullUrl = `https://top.gg/api${path}`;
   const url = path;
   return (
     <HeaderWrapper method={type}>


### PR DESCRIPTION
This should fix the double slash when clicking the copy URL.

As the `/` is already defined by the path, the `/` before `${path}` was not needed.