### PR TITLE
Removed response example

### DIFF
--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -149,14 +149,6 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 | shard_id     | `number`               | The zero-indexed id of the shard posting. Makes server_count set the shard specific server count. | ❌       |
 | shard_count  | `number`               | The amount of shards the bot has.                                                                 | ❌       |
 
-### Example Response
-
-```json:title=/bots/9876/check?userId%3D1234
-{
-  "voted": 1
-}
-```
-
 ## Bot Structure
 
 | Field            | Type          | Description                                                                   |


### PR DESCRIPTION
This is the fix to #34 

As seen after posting the stats there is no response given:
![image](https://user-images.githubusercontent.com/43011723/118699937-621e3100-b812-11eb-9fd3-9019d329e7b4.png)

Therefore I completely removed the example response as you don't really need to know that.