### PR TITLE
Ensure that path doesn't contain double slashes

### DIFF
--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -86,7 +86,7 @@ Finds a single bot
 
 Gets the last 1000 voters for your bot.
 
-> If your bot receives more than 1000 votes monthly you cannot use this endpoints and must use `webhooks` and implement your own caching instead.
+> If your bot receives more than 1000 votes monthly you cannot use this endpoints and must use [`webhooks`](/resources/webhooks) and implement your own caching instead.
 
 This example uses Luca but users are restricted to only receiving their own bots' votes. Replace the id with your own bot.
 

--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -9,7 +9,7 @@ import HTTPHeader from "@components/HTTPHeader";
 
 ## Search Bots
 
-<HTTPHeader type="GET" path="bots" />
+<HTTPHeader type="GET" path="/bots" />
 
 Gets a list of bots that match a specific query.
 
@@ -72,7 +72,7 @@ Gets a list of bots that match a specific query.
 
 ## Find One Bot
 
-<HTTPHeader type="GET" path="bots/:bot_id" />
+<HTTPHeader type="GET" path="/bots/:bot_id" />
 
 Finds a single bot
 
@@ -82,7 +82,7 @@ Finds a single bot
 
 ## Last 1000 Votes
 
-<HTTPHeader type="GET" path="bots/:bot_id/votes" />
+<HTTPHeader type="GET" path="/bots/:bot_id/votes" />
 
 Gets the last 1000 voters for your bot.
 
@@ -104,7 +104,7 @@ This example uses Luca but users are restricted to only receiving their own bots
 
 ## Bot stats
 
-<HTTPHeader type="GET" path="bots/:bot_id/stats" />
+<HTTPHeader type="GET" path="/bots/:bot_id/stats" />
 
 Specific stats about a bot.
 
@@ -118,7 +118,7 @@ Specific stats about a bot.
 
 ## Individual User Vote
 
-<HTTPHeader type="GET" path="bots/:bot_id/check" />
+<HTTPHeader type="GET" path="/bots/:bot_id/check" />
 
 Checking whether or not a user has voted for your bot. Safe to use even if you have over 1k monthly votes.
 
@@ -138,7 +138,7 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 
 ## Post Stats
 
-<HTTPHeader type="POST" path="bots/:bot_id/stats" />
+<HTTPHeader type="POST" path="/bots/:bot_id/stats" />
 
 ### Post Body
 

--- a/content/api/user.mdx
+++ b/content/api/user.mdx
@@ -9,7 +9,7 @@ A user represents a User account in top.gg. It is not associated with any other 
 
 ## Find One User
 
-<HTTPHeader type="GET" path="users/:user_id" />
+<HTTPHeader type="GET" path="/users/:user_id" />
 
 Retrieves information about a particular user by their Discord user id.
 

--- a/src/components/HTTPHeader.jsx
+++ b/src/components/HTTPHeader.jsx
@@ -64,8 +64,8 @@ export default function HTTPHeader({ type, path }) {
       setTimeout(() => setCopy(false), 3000);
     }
   }, [copied]);
-  const BASE_URL = "https://top.gg/api/";
-  const fullUrl = new URL(path, BASE_URL).href;
+  const BASE_URL = "https://top.gg/";
+  const fullUrl = new URL(`api${path.startsWith("/") ? "" : "/"}${path}`, BASE_URL).href;
   const url = path;
   return (
     <HeaderWrapper method={type}>

--- a/src/components/HTTPHeader.jsx
+++ b/src/components/HTTPHeader.jsx
@@ -65,7 +65,8 @@ export default function HTTPHeader({ type, path }) {
     }
   }, [copied]);
   const BASE_URL = "https://top.gg/";
-  const fullUrl = new URL(`api${path.startsWith("/") ? "" : "/"}${path}`, BASE_URL).href;
+  path = `${path.startsWith("/") ? "" : "/"}${path}`
+  const fullUrl = new URL(`api${path}`, BASE_URL).href;
   const url = path;
   return (
     <HeaderWrapper method={type}>

--- a/src/components/HTTPHeader.jsx
+++ b/src/components/HTTPHeader.jsx
@@ -64,8 +64,19 @@ export default function HTTPHeader({ type, path }) {
       setTimeout(() => setCopy(false), 3000);
     }
   }, [copied]);
-  const BASE_URL = "https://top.gg/";
-  path = `${path.startsWith("/") ? "" : "/"}${path}`
+  const BASE_URL = "https://top.gg/api";
+  if (path.startsWith(BASE_URL)) {
+    path = path.replace(BASE_URL, "");
+  }
+  if (path.startsWith("api")) {
+    path = path.replace("api", "");
+  }
+  else if (path.startsWith("/api")) {
+    path = path.replace("/api", "")
+  }
+  else if (!path.startsWith("/")) {
+    path = `/${path}`
+  }
   const fullUrl = new URL(`api${path}`, BASE_URL).href;
   const url = path;
   return (


### PR DESCRIPTION
This PR proposes consistency regarding slashes in endpoint URLs to make sure that double slashes are not present in the path while still displaying the path with a leading slash.