### PR TITLE
Update javascript AutoPoster example

### DIFF
--- a/content/libraries/javascript.mdx
+++ b/content/libraries/javascript.mdx
@@ -22,7 +22,7 @@ Posting your bot's statistics is a quick and easy way to show how many people us
 
 ```js:title=/index.js
 const client = new Discord.Client() // Your discord.js or eris client (or djs ShardingManager)
-const AutoPoster = require('topgg-autoposter')
+const { AutoPoster } = require('topgg-autoposter')
 
 const ap = AutoPoster('Your Top.gg Token', client)
 


### PR DESCRIPTION
Due to the new topgg-autoposter version, a breaking importing change makes AutoPoster exported via AutoPoster rather than the default export.