### PR TITLE
Channel name rename

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -11,6 +11,6 @@ If you're looking for API usage, check out the `API` section on the sidebar.
 
 ## Getting Help
 
-If you need some help or think you have spotted a problem with our API you can talk to us in our [`#api`](https://discord.com/channels/264445053596991498/412006692125933568) channel in our [discord server](https://discord.gg/EYHTgJX).
+If you need some help or think you have spotted a problem with our API you can talk to us in our [`#topgg-api`](https://discord.com/channels/264445053596991498/412006692125933568) channel in our [discord server](https://discord.gg/EYHTgJX).
 
 In the server you can ask questions about our official API Libraries or general queries about the API.


### PR DESCRIPTION
Since the #api channel has been renamed to #topgg-api on the Discord server, I changed the name in the docs.