### PR TITLE
Removed Bot library from bot post stats

### DIFF
--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -158,6 +158,7 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 | discriminator    | `string`      | The discriminator of the bot                                                  |
 | avatar?          | `string`      | The avatar hash of the bot's avatar                                           |
 | defAvatar        | `string`      | The cdn hash of the bot's avatar if the bot has none                          |
+| lib              | `string`      | The library of the bot :warning: Deprecated                                   |
 | prefix           | `string`      | The prefix of the bot                                                         |
 | shortdesc        | `string`      | The short description of the bot                                              |
 | longdesc?        | `string`      | The long description of the bot. Can contain HTML and/or Markdown             |

--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -158,7 +158,6 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 | discriminator    | `string`      | The discriminator of the bot                                                  |
 | avatar?          | `string`      | The avatar hash of the bot's avatar                                           |
 | defAvatar        | `string`      | The cdn hash of the bot's avatar if the bot has none                          |
-| lib              | `string`      | The library of the bot                                                        |
 | prefix           | `string`      | The prefix of the bot                                                         |
 | shortdesc        | `string`      | The short description of the bot                                              |
 | longdesc?        | `string`      | The long description of the bot. Can contain HTML and/or Markdown             |


### PR DESCRIPTION
The bot library was still shown in the docs even though it's outdated and we can no longer set it, and it can cause misleading when users read the docs