### PR TITLE
Fixed ratelimits retry-after documented as millseconds while it's seconds

### DIFF
--- a/content/resources/ratelimits.mdx
+++ b/content/resources/ratelimits.mdx
@@ -27,10 +27,10 @@ If you exceed the set rate limit for the API you will receive a HTTP 429 and be 
 
 ```json:title=HTTP%20429
 {
-  "retry-after": 3600000
+  "retry-after": 3600
 }
 ```
 
-| Field       | Type    | Description                                                        |
-| ----------- | ------- | ------------------------------------------------------------------ |
-| retry-after | integer | The millisecond timeout before you are able to send requests again |
+| Field       | Type    | Description                                                       |
+| ----------- | ------- | ----------------------------------------------------------------- |
+| retry-after | integer | The timeout in seconds before you are able to send requests again |

--- a/content/resources/ratelimits.mdx
+++ b/content/resources/ratelimits.mdx
@@ -31,6 +31,6 @@ If you exceed the set rate limit for the API you will receive a HTTP 429 and be 
 }
 ```
 
-| Field       | Type    | Description                                                       |
-| ----------- | ------- | ----------------------------------------------------------------- |
-| retry-after | integer | The timeout in seconds before you are able to send requests again |
+| Field       | Type    | Description                                                                                                                                                                   |
+| ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| retry-after | integer | The timeout in seconds before you are able to send requests again. Learn more about this header [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) |


### PR DESCRIPTION
API returns `retry-after` header in seconds but it's currently showing as milliseconds in docs. This PR fixes that issue