### PR TITLE
Add "--no-deps" install method

### DIFF
--- a/content/libraries/python.mdx
+++ b/content/libraries/python.mdx
@@ -18,6 +18,12 @@ The community-maintained Python Library for Top.gg, if you experience any issues
 pip install topggpy
 ```
 
+### Not using Discord.py?
+
+```
+pip install topggpy --no-deps
+```
+
 ### Install from source
 
 ```


### PR DESCRIPTION
Add "--no-deps" install method for those not using Discord.py and instead using alternative libraries like Disnake or Pycord