### PR TITLE
Added docs for server webhooks

### DIFF
--- a/content/resources/webhooks.mdx
+++ b/content/resources/webhooks.mdx
@@ -7,7 +7,15 @@ Instead of requesting our API to see the users who have voted for your bot, you 
 
 ## Getting Started
 
-Start by setting up your webhook URL in the edit form of your bot on this site, it can be found at https://top.gg/bot/:your-bot-id/webhooks (Replace `:your-bot-id` with your bot's ID!). Once you've entered the URL you want the webhook to be sent to, you're all set! If you need help setting up webhooks inside of your bot don't be afraid to ask in our [discord server](https://discord.gg/dbl) in the `#topgg-api` channel.
+### For Bots
+
+Start by setting up your webhook URL in the edit form of your bot on this site, it can be found at https://top.gg/servers/:your-server-id/webhooks (Replace `:your-bot-id` with your bot's ID!)
+
+### For Servers
+
+Start by setting up your webhook URL in the edit form of your server on this site, it can be found at https://top.gg/bot/:your-server-id/webhooks (Replace `:your-server-id` with your server's ID!. [Here's how you can find your server's id](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-)
+
+Once you've entered the URL you want the webhook to be sent to, you're all set! If you need help setting up webhooks inside of your bot/server don't be afraid to ask in our [discord server](https://discord.gg/dbl) in the `#topgg-api` channel.
 
 ## Security
 

--- a/content/resources/webhooks.mdx
+++ b/content/resources/webhooks.mdx
@@ -9,11 +9,11 @@ Instead of requesting our API to see the users who have voted for your bot, you 
 
 ### For Bots
 
-Start by setting up your webhook URL in the edit form of your bot on this site, it can be found at https://top.gg/servers/:your-server-id/webhooks (Replace `:your-bot-id` with your bot's ID!)
+Start by setting up your webhook URL in the edit form of your bot on this site, it can be found at https://top.gg/bot/:your-bot-id/webhooks (Replace `:your-bot-id` with your bot's ID!)
 
 ### For Servers
 
-Start by setting up your webhook URL in the edit form of your server on this site, it can be found at https://top.gg/bot/:your-server-id/webhooks (Replace `:your-server-id` with your server's ID!. [Here's how you can find your server's id](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-)
+Start by setting up your webhook URL in the edit form of your server on this site, it can be found at https://top.gg/servers/:your-server-id/webhooks (Replace `:your-server-id` with your server's ID!. [Here's how you can find your server's id](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-)
 
 Once you've entered the URL you want the webhook to be sent to, you're all set! If you need help setting up webhooks inside of your bot/server don't be afraid to ask in our [discord server](https://discord.gg/dbl) in the `#topgg-api` channel.
 


### PR DESCRIPTION
At the docs at [docs.top.gg/resources/webhooks/](https://docs.top.gg/resources/webhooks/) in the description it only shows docs for bot webhooks
![image](https://user-images.githubusercontent.com/58624651/177482854-862834d1-1e39-4853-9208-613b0379bf8c.png)
In this pull I added support for servers too  
  
  
UwU