### PR TITLE
Add missing clientid field to bot structure.

### DIFF
--- a/content/api/bot.mdx
+++ b/content/api/bot.mdx
@@ -156,6 +156,7 @@ Checking whether or not a user has voted for your bot. Safe to use even if you h
 | Field            | Type          | Description                                                                   |
 | ---------------- | ------------- | ----------------------------------------------------------------------------- |
 | id               | `string`      | The id of the bot                                                             |
+| clientid         | `string`      | The client id of the bot
 | username         | `string`      | The username of the bot                                                       |
 | discriminator    | `string`      | The discriminator of the bot                                                  |
 | avatar?          | `string`      | The avatar hash of the bot's avatar                                           |


### PR DESCRIPTION
In the example structure the clientid value is present, however, it is missing in the bot structure above