### PR TITLE
fix: hopefully fix syntax highlighting and update headings

### DIFF
--- a/docs/Libraries/rust.mdx
+++ b/docs/Libraries/rust.mdx
@@ -41,7 +41,7 @@ This library provides several feature flags that can be enabled/disabled in `Car
 
 #### Fetching a single Discord user from it's Discord ID
 
-```rust,no_run
+```rs
 use topgg::Client;
 
 #[tokio::main]
@@ -58,7 +58,7 @@ async fn main() {
 
 #### Posting your Discord bot's statistics
 
-```rust,no_run
+```rs
 use topgg::{Client, Stats};
 
 #[tokio::main]
@@ -75,7 +75,7 @@ async fn main() {
 
 #### Checking if a user has voted your Discord bot
 
-```rust,no_run
+```rs
 use topgg::Client;
 
 #[tokio::main]
@@ -103,7 +103,7 @@ topgg = { version = "1.4", features = ["autoposter", "serenity-cached"] }
 
 In your code:
 
-```rust,no_run
+```rs
 use core::time::Duration;
 use serenity::{client::{Client, Context, EventHandler}, model::{channel::Message, gateway::Ready}};
 use topgg::Autoposter;
@@ -160,7 +160,7 @@ topgg = { version = "1.4", features = ["autoposter", "twilight-cached"] }
 
 In your code:
 
-```rust,no_run
+```rs
 use core::time::Duration;
 use topgg::Autoposter;
 use twilight_gateway::{Event, Intents, Shard, ShardId};
@@ -212,7 +212,7 @@ topgg = { version = "1.4", default-features = false, features = ["actix-web"] }
 
 In your code:
 
-```rust,no_run
+```rs
 use actix_web::{
   error::{Error, ErrorUnauthorized},
   get, post, App, HttpServer,
@@ -257,7 +257,7 @@ topgg = { version = "1.4", default-features = false, features = ["axum"] }
 
 In your code:
 
-```rust,no_run
+```rs
 use axum::{routing::get, Router, Server};
 use std::{net::SocketAddr, sync::Arc};
 use topgg::{Vote, VoteHandler};
@@ -304,7 +304,7 @@ topgg = { version = "1.4", default-features = false, features = ["rocket"] }
 
 In your code:
 
-```rust,no_run
+```rs
 #![feature(decl_macro)]
 
 use rocket::{get, http::Status, post, routes};
@@ -349,7 +349,7 @@ topgg = { version = "1.4", default-features = false, features = ["warp"] }
 
 In your code:
 
-```rust,no_run
+```rs
 use std::{net::SocketAddr, sync::Arc};
 use topgg::{Vote, VoteHandler};
 use warp::Filter;

--- a/docs/Libraries/rust.mdx
+++ b/docs/Libraries/rust.mdx
@@ -39,7 +39,7 @@ This library provides several feature flags that can be enabled/disabled in `Car
 
 ## Examples
 
-#### Fetching a single Discord user from it's Discord ID
+### Fetching a user from its Discord ID
 
 ```rs
 use topgg::Client;
@@ -56,7 +56,7 @@ async fn main() {
 }
 ```
 
-#### Posting your Discord bot's statistics
+### Posting your bot's statistics
 
 ```rs
 use topgg::{Client, Stats};
@@ -73,7 +73,7 @@ async fn main() {
 }
 ```
 
-#### Checking if a user has voted your Discord bot
+### Checking if a user has voted your bot
 
 ```rs
 use topgg::Client;
@@ -88,7 +88,7 @@ async fn main() {
 }
 ```
 
-#### Automating the process of periodically posting your Discord bot's statistics with the [serenity](https://crates.io/crates/serenity) library
+### Autoposting with [serenity](https://crates.io/crates/serenity)
 
 In your `Cargo.toml`:
 
@@ -145,7 +145,7 @@ async fn main() {
 }
 ```
 
-#### Automating the process of periodically posting your Discord bot's statistics with the [twilight](https://twilight.rs) library
+### Autoposting with [twilight](https://twilight.rs)
 
 In your `Cargo.toml`:
 
@@ -201,7 +201,7 @@ async fn main() {
 }
 ```
 
-#### Writing an [actix-web](https://actix.rs) webhook for listening to your bot/server's vote events
+### Writing an [actix-web](https://actix.rs) webhook for listening to votes
 
 In your `Cargo.toml`:
 
@@ -246,7 +246,7 @@ async fn main() -> io::Result<()> {
 }
 ```
 
-#### Writing an [axum](https://crates.io/crates/axum) webhook for listening to your bot/server's vote events
+### Writing an [axum](https://crates.io/crates/axum) webhook for listening to votes
 
 In your `Cargo.toml`:
 
@@ -293,7 +293,7 @@ async fn main() {
 }
 ```
 
-#### Writing a [rocket](https://rocket.rs) webhook for listening to your bot/server's vote events
+### Writing a [rocket](https://rocket.rs) webhook for listening to votes
 
 In your `Cargo.toml`:
 
@@ -338,7 +338,7 @@ fn main() {
 }
 ```
 
-#### Writing a [warp](https://crates.io/crates/warp) webhook for listening to your bot/server's vote events
+### Writing a [warp](https://crates.io/crates/warp) webhook for listening to votes
 
 In your `Cargo.toml`:
 


### PR DESCRIPTION
The following pull request (hopefully) fixes the problem where Rust codeblocks are not properly syntax highlighted in https://docs.top.gg and also update some headings.

Another pull request in the rust sdk has been created to reflect this change: https://github.com/Top-gg-Community/rust-sdk/pull/19